### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/src/main/resources/archetype-resources/README.adoc
+++ b/src/main/resources/archetype-resources/README.adoc
@@ -26,7 +26,7 @@
 :linkcss: false
 
 :short-bonita-version: ${shortBonitaVersion}
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version:#if( $after10 ) 17#elseif ( $after713 ) 11#else 8#end
 
 = ${artifactId}

--- a/src/test/resources/projects/testActorFilterKotlinProject/reference/README.adoc
+++ b/src/test/resources/projects/testActorFilterKotlinProject/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 = actorfilter-kotlin-test
 

--- a/src/test/resources/projects/testActorFilterKotlinProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testActorFilterKotlinProject7_13/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = actorfilter-kotlin-test
 

--- a/src/test/resources/projects/testActorfilterGroovyProject/reference/README.adoc
+++ b/src/test/resources/projects/testActorfilterGroovyProject/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 = actorfilter-groovy-test
 

--- a/src/test/resources/projects/testActorfilterGroovyProject10/reference/README.adoc
+++ b/src/test/resources/projects/testActorfilterGroovyProject10/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 10.0
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 = actorfilter-groovy-test
 

--- a/src/test/resources/projects/testActorfilterGroovyProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testActorfilterGroovyProject7_13/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = actorfilter-groovy-test
 

--- a/src/test/resources/projects/testActorfilterJava11Project/reference/README.adoc
+++ b/src/test/resources/projects/testActorfilterJava11Project/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = actorfilter-java-test
 

--- a/src/test/resources/projects/testActorfilterJavaProject/reference/README.adoc
+++ b/src/test/resources/projects/testActorfilterJavaProject/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 = actorfilter-java-test
 


### PR DESCRIPTION
## Summary
- Replace `documentation.bonitasoft.com` -> `documentation.ofelia.com`
- Replace `community.bonitasoft.com` -> `community.ofelia.com`
- Replace `www.bonitasoft.com` -> `www.ofelia.com`

Affects README and archetype template files only. No logic changes.

Part of the Bonitasoft -> Ofelia rebranding initiative.